### PR TITLE
Fix TDW lm_agent.py dropping behavior for lm_agent when holding multiple objects

### DIFF
--- a/tdw_mat/tdw-gym/lm_agent.py
+++ b/tdw_mat/tdw-gym/lm_agent.py
@@ -508,10 +508,12 @@ class lm_agent:
                 self.object_map[np.where(self.id_map == self.last_action['object'])] = 0
                 self.id_map[np.where(self.id_map == self.last_action['object'])] = 0
         if len(self.dropping_object) > 0 and self.obs['status'] == 1:
-            self.logger.info("successful drop!")
+            self.logger.info(f"Drop object: {self.dropping_object}")
             self.satisfied += self.dropping_object
             self.dropping_object = []
-            self.plan = None
+            if len(self.holding_objects_id) == 0:
+                self.logger.info("successful drop!")
+                self.plan = None
 
         ignore_obstacles = []
         ignore_ids = []


### PR DESCRIPTION
### Description:
This PR addresses an issue where the lm_agent prematurely terminates its plan after dropping only one object when holding multiple objects without using a basket. The previous implementation removed the agent's plan immediately after dropping any object, resulting in incomplete object placement.

### Changes:
- Updated the act interface of lm_agent to retain the agent's plan until all held objects have been successfully dropped.
- Modified logging to provide clearer insights into the drop actions being performed.

### Before:
```python
if len(self.dropping_object) > 0 and self.obs['status'] == 1:
    self.logger.info("successful drop!")
    self.satisfied += self.dropping_object
    self.dropping_object = []
    self.plan = None
```

### After:
```python
if len(self.dropping_object) > 0 and self.obs['status'] == 1:
    self.logger.info(f"Drop object: {self.dropping_object}")
    self.satisfied += self.dropping_object
    self.dropping_object = []
    if len(self.holding_objects_id) == 0:
        self.logger.info("successful drop!")
        self.plan = None
```

With this adjustment, the agent now correctly waits until all objects have been dropped before terminating its plan, ensuring consistent and expected behavior.
This update improves performance reproducibility in settings with oracle observations, although I still experience challenges in reproducing performance using the visual detector. #37 
 
